### PR TITLE
add com.nae.calendar.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ vite.config.ts.timestamp-*
 
 electron
 dist_build
+com.nae.calendar.*


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add `com.nae.calendar.*` pattern to `.gitignore` to exclude related files from tracking